### PR TITLE
docs: fix action version in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This example will:
 + Drop all the draft release.
 
 ```yml
-  - uses: sgpublic/delete-release-action@main
+  - uses: sgpublic/delete-release-action@v1
     with:
       # repo: '<owner>/<repoName>' # you can input a another repo here, defaults to current repo
       release-drop: true


### PR DESCRIPTION
Since your repository does not contain branch `main` but has a tag `v1` I've changed example to use `v1` tag.