### PR TITLE
Fix filtering and load all releases

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -41,7 +41,7 @@ inputs:
     required: true
     default: '-1'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'
 branding:
   icon: 'package'

--- a/dist/index.js
+++ b/dist/index.js
@@ -9733,7 +9733,7 @@ function run() {
         core.info(`Releases total count: ${allReleases.length}`);
         if (Input_1.Input.Release.DROP) {
             const releases = allReleases.filter((release) => {
-                (!release.draft && !release.prerelease);
+                return !release.draft && !release.prerelease;
             });
             if (releases.length > 0) {
                 core.info(`Filtered release count: ${releases.length}`);
@@ -9748,7 +9748,7 @@ function run() {
         }
         if (Input_1.Input.PreRelease.DROP) {
             const prereleases = allReleases.filter((release) => {
-                (release.prerelease && !release.draft);
+                return release.prerelease && !release.draft;
             });
             if (prereleases.length > 0) {
                 core.info(`Filtered pre-release count: ${prereleases.length}`);

--- a/dist/index.js
+++ b/dist/index.js
@@ -9547,26 +9547,28 @@ const core = __importStar(__nccwpck_require__(2186));
 const Input_1 = __nccwpck_require__(2660);
 class Github {
     constructor() {
-        this.octokit = github.getOctokit(Input_1.Input.Github.TOKEN).rest;
+        const octokit = github.getOctokit(Input_1.Input.Github.TOKEN);
+        this.octokitRest = octokit.rest;
+        this.octokitPaginate = octokit.paginate;
     }
-    listRelease() {
+    listReleases() {
         return __awaiter(this, void 0, void 0, function* () {
-            return (yield this.octokit.repos.listReleases(Input_1.Input.Github.REPO)).data;
+            return (yield this.octokitPaginate("GET /repos/:owner/:repo/releases", Input_1.Input.Github.REPO));
         });
     }
     dropRelease(release, dropTag) {
         return __awaiter(this, void 0, void 0, function* () {
             for (const asset of release.assets) {
-                yield this.octokit.repos.deleteReleaseAsset(Object.assign(Input_1.Input.Github.REPO, { asset_id: asset.id }));
-                core.debug(`drop release assets: [${release.name}] ${asset.name}`);
+                yield this.octokitRest.repos.deleteReleaseAsset(Object.assign(Input_1.Input.Github.REPO, { asset_id: asset.id }));
+                core.debug(`Release asset dropped: [${release.name}] ${asset.name}`);
             }
-            core.debug(`drop release: ${release.name}`);
-            yield this.octokit.repos.deleteRelease(Object.assign(Input_1.Input.Github.REPO, { release_id: release.id }));
+            core.debug(`Drop release: ${release.name}`);
+            yield this.octokitRest.repos.deleteRelease(Object.assign(Input_1.Input.Github.REPO, { release_id: release.id }));
             if (!dropTag)
                 return;
-            core.debug(`drop tag: ${release.tag_name}`);
-            yield this.octokit.git.deleteRef(Object.assign(Input_1.Input.Github.REPO, { ref: `tags/${release.tag_name}` }));
-            core.info(`release dropped: ${release.name}`);
+            core.debug(`Drop tag: ${release.tag_name}`);
+            yield this.octokitRest.git.deleteRef(Object.assign(Input_1.Input.Github.REPO, { ref: `tags/${release.tag_name}` }));
+            core.info(`Release dropped: ${release.name}`);
         });
     }
     static getInstance() {
@@ -9722,52 +9724,52 @@ const Github_1 = __nccwpck_require__(6703);
 const Input_1 = __nccwpck_require__(2660);
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
-        const release = yield Github_1.Github.getInstance().listRelease();
-        core.debug(`release list data: \n${release}`);
-        if (release.length <= 0) {
-            core.info(`No release found, action finish!`);
+        const allReleases = yield Github_1.Github.getInstance().listReleases();
+        core.debug(`Releases list data: \n${allReleases}`);
+        if (allReleases.length <= 0) {
+            core.info(`No releases found, action finished!`);
             return;
         }
-        core.info(`Release total count: ${release.length}`);
+        core.info(`Releases total count: ${allReleases.length}`);
         if (Input_1.Input.Release.DROP) {
-            const releases = release.filter((release) => {
+            const releases = allReleases.filter((release) => {
                 (!release.draft && !release.prerelease);
             });
-            if (release.length > 0) {
-                core.info(`Find release count: ${release.length}`);
-                yield dropRelease(releases, Input_1.Input.Release.KEEP_COUNT + 1, Input_1.Input.Release.DROP_TAG);
+            if (releases.length > 0) {
+                core.info(`Filtered release count: ${releases.length}`);
+                yield dropReleases(releases, Input_1.Input.Release.KEEP_COUNT + 1, Input_1.Input.Release.DROP_TAG);
             }
             else {
-                core.warning(`No release found, skip action.`);
+                core.warning(`No releases found, skip action.`);
             }
         }
         else {
             core.info(`Skip drop release.`);
         }
         if (Input_1.Input.PreRelease.DROP) {
-            const prereleases = release.filter((release) => {
+            const prereleases = allReleases.filter((release) => {
                 (release.prerelease && !release.draft);
             });
             if (prereleases.length > 0) {
-                core.info(`Find pre-release count: ${prereleases.length}`);
-                yield dropRelease(prereleases, Input_1.Input.PreRelease.KEEP_COUNT + 1, Input_1.Input.PreRelease.DROP_TAG);
+                core.info(`Filtered pre-release count: ${prereleases.length}`);
+                yield dropReleases(prereleases, Input_1.Input.PreRelease.KEEP_COUNT + 1, Input_1.Input.PreRelease.DROP_TAG);
             }
             else {
-                core.warning(`No pre-release found, skip action.`);
+                core.warning(`No pre-releases found, skip action.`);
             }
         }
         else {
             core.info(`Skip drop pre-release.`);
         }
         if (Input_1.Input.Draft.DROP) {
-            const draft = (yield Github_1.Github.getInstance().listRelease())
+            const drafts = (yield Github_1.Github.getInstance().listReleases())
                 .filter((release) => release.draft);
-            if (draft.length > 0) {
-                core.info(`Find draft count: ${draft.length}`);
-                yield dropRelease(draft, Input_1.Input.Draft.KEEP_COUNT + 1, false);
+            if (drafts.length > 0) {
+                core.info(`Filtered draft count: ${drafts.length}`);
+                yield dropReleases(drafts, Input_1.Input.Draft.KEEP_COUNT + 1, false);
             }
             else {
-                core.warning(`No draft found, skip action.`);
+                core.warning(`No drafts found, skip action.`);
             }
         }
         else {
@@ -9776,7 +9778,7 @@ function run() {
         core.info(`All task finished!`);
     });
 }
-function dropRelease(releases, keep, dropTag) {
+function dropReleases(releases, keep, dropTag) {
     return __awaiter(this, void 0, void 0, function* () {
         const sorted = releases.sort(function (rA, rB) {
             if (rB.published_at != null && rA.published_at) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "delete-release-action",
-  "version": "1.0.0",
+  "version": "1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "delete-release-action",
-      "version": "1.0.0",
+      "version": "1.1",
       "license": "GPL-3.0",
       "dependencies": {
         "@actions/core": "^1.10.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ async function run() {
 
     if (Input.Release.DROP) {
         const releases = allReleases.filter((release: any) => {
-            (!release.draft && !release.prerelease)
+            return !release.draft && !release.prerelease
         });
         if (releases.length > 0) {
             core.info(`Filtered release count: ${releases.length}`);
@@ -27,7 +27,7 @@ async function run() {
 
     if (Input.PreRelease.DROP) {
         const prereleases = allReleases.filter((release: any) => {
-            (release.prerelease && !release.draft)
+            return release.prerelease && !release.draft
         });
         if (prereleases.length > 0) {
             core.info(`Filtered pre-release count: ${prereleases.length}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,37 +3,37 @@ import {Github} from "./core/Github";
 import {Input} from "./core/Input";
 
 async function run() {
-    const release = await Github.getInstance().listRelease();
-    core.debug(`release list data: \n${release}`)
-    if (release.length <= 0) {
-        core.info(`No release found, action finish!`);
+    const allReleases = await Github.getInstance().listReleases();
+    core.debug(`Releases list data: \n${allReleases}`)
+    if (allReleases.length <= 0) {
+        core.info(`No releases found, action finished!`);
         return;
     }
-    core.info(`Release total count: ${release.length}`);
+    core.info(`Releases total count: ${allReleases.length}`);
 
     if (Input.Release.DROP) {
-        const releases = release.filter((release: any) => {
+        const releases = allReleases.filter((release: any) => {
             (!release.draft && !release.prerelease)
         });
-        if (release.length > 0) {
-            core.info(`Find release count: ${release.length}`);
-            await dropRelease(releases, Input.Release.KEEP_COUNT + 1, Input.Release.DROP_TAG);
+        if (releases.length > 0) {
+            core.info(`Filtered release count: ${releases.length}`);
+            await dropReleases(releases, Input.Release.KEEP_COUNT + 1, Input.Release.DROP_TAG);
         } else {
-            core.warning(`No release found, skip action.`);
+            core.warning(`No releases found, skip action.`);
         }
     } else {
         core.info(`Skip drop release.`);
     }
 
     if (Input.PreRelease.DROP) {
-        const prereleases = release.filter((release: any) => {
+        const prereleases = allReleases.filter((release: any) => {
             (release.prerelease && !release.draft)
         });
         if (prereleases.length > 0) {
-            core.info(`Find pre-release count: ${prereleases.length}`);
-            await dropRelease(prereleases, Input.PreRelease.KEEP_COUNT + 1, Input.PreRelease.DROP_TAG);
+            core.info(`Filtered pre-release count: ${prereleases.length}`);
+            await dropReleases(prereleases, Input.PreRelease.KEEP_COUNT + 1, Input.PreRelease.DROP_TAG);
         } else {
-            core.warning(`No pre-release found, skip action.`);
+            core.warning(`No pre-releases found, skip action.`);
         }
     } else {
         core.info(`Skip drop pre-release.`);
@@ -41,13 +41,13 @@ async function run() {
 
 
     if (Input.Draft.DROP) {
-        const draft = (await Github.getInstance().listRelease())
+        const drafts = (await Github.getInstance().listReleases())
             .filter((release: any) => release.draft);
-        if (draft.length > 0) {
-            core.info(`Find draft count: ${draft.length}`);
-            await dropRelease(draft, Input.Draft.KEEP_COUNT + 1, false);
+        if (drafts.length > 0) {
+            core.info(`Filtered draft count: ${drafts.length}`);
+            await dropReleases(drafts, Input.Draft.KEEP_COUNT + 1, false);
         } else {
-            core.warning(`No draft found, skip action.`);
+            core.warning(`No drafts found, skip action.`);
         }
     } else {
         core.info(`Skip drop draft.`);
@@ -56,7 +56,7 @@ async function run() {
     core.info(`All task finished!`);
 }
 
-async function dropRelease(releases: any, keep: number, dropTag: boolean) {
+async function dropReleases(releases: any, keep: number, dropTag: boolean) {
     const sorted = releases.sort(
         function (rA: any, rB: any) {
             if (rB.published_at != null && rA.published_at){


### PR DESCRIPTION
This fixes #6 and couple other issues, complete list of fixes:

- Fixes wrong count shown for filtered releases
- Fixes releases and pre-releases filtering (was missing return)
- Fixes not loading all releases (currently loads max 30 releases)
- Updates node version to avoid github action warning

Also improved bit the logging wording to sound more correct and clarified the code a bit by not using overlapping variable names.